### PR TITLE
Dependency Update Day 2025-12-08

### DIFF
--- a/botocore.cabal
+++ b/botocore.cabal
@@ -31,11 +31,11 @@ library
 
   build-depends:
     , aeson         ^>=2.1.2.0 || ^>=2.2
-    , barbies       ^>=2.0.5.0
+    , barbies       ^>=2.0.5.0 || ^>=2.1
     , barbies-th    ^>=0.1.10
     , base          >=4.14     && <4.22
-    , containers    ^>=0.6.5   || ^>=0.7
-    , generic-lens  ^>=2.2.2.0
+    , containers    ^>=0.6.5   || ^>=0.7 || ^>=0.8
+    , generic-lens  ^>=2.2.2.0 || ^>=2.3
     , scientific    ^>=0.3.7.0
     , some          ^>=1.0.6
     , text          ^>=1.2     || ^>=2.0 || ^>=2.1


### PR DESCRIPTION
## Summary
- Updated dependency version bounds
  - barbies: added ^>=2.1 support
  - containers: added ^>=0.8 support
  - generic-lens: added ^>=2.3 support (upgraded to 2.3.0.0)

## Test plan
- ✅ `nix develop` works with GHC 9.4.8
- ✅ `nix develop .#ghc96` works with GHC 9.6.7
- ✅ `cabal build all` succeeds on both GHC versions
- ✅ `cabal outdated` shows no further updates available
- ✅ Project has no test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)