### PR TITLE
2026-02-17 dependency updates

### DIFF
--- a/botocore.cabal
+++ b/botocore.cabal
@@ -16,7 +16,7 @@ copyright:       Copyright (c) 2023 Bellroy Pty Ltd
 category:        AWS
 build-type:      Simple
 extra-doc-files: README.md
-tested-with:     GHC ==9.2.5 || ==9.4.8 || ==9.6.6
+tested-with:     GHC ==9.4.8 || ==9.6.7
 
 source-repository head
   type:     git
@@ -33,7 +33,7 @@ library
     , aeson         ^>=2.1.2.0 || ^>=2.2
     , barbies       ^>=2.0.5.0 || ^>=2.1
     , barbies-th    ^>=0.1.10
-    , base          >=4.14     && <4.22
+    , base          >=4.14     && <4.23
     , containers    ^>=0.6.5   || ^>=0.7 || ^>=0.8
     , generic-lens  ^>=2.2.2.0 || ^>=2.3
     , scientific    ^>=0.3.7.0

--- a/botocore.cabal
+++ b/botocore.cabal
@@ -16,7 +16,7 @@ copyright:       Copyright (c) 2023 Bellroy Pty Ltd
 category:        AWS
 build-type:      Simple
 extra-doc-files: README.md
-tested-with:     GHC ==9.4.8 || ==9.6.7
+tested-with:     GHC ==9.2.5 || ==9.4.8 || ==9.6.7
 
 source-repository head
   type:     git

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1760401436,
-        "narHash": "sha256-77cVIdd6w/yXWX4Ys+BUDS+BE2ynZj0iOwkcQvZsnA8=",
+        "lastModified": 1771297770,
+        "narHash": "sha256-tbFGVRLVytQGQgZZkJAwyge6ISpojHiR7TxQws51jBA=",
         "owner": "bellroy",
         "repo": "bellroy-nix-foss",
-        "rev": "e250ce4f1565307993163b8615dcdbd207e68703",
+        "rev": "a52e52ca9a21bd32f45662f43fceca9e0b30fe48",
         "type": "github"
       },
       "original": {
@@ -23,15 +23,15 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1747046372,
-        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
-        "owner": "edolstra",
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
         "repo": "flake-compat",
-        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
         "type": "github"
       },
       "original": {
-        "owner": "edolstra",
+        "owner": "NixOS",
         "repo": "flake-compat",
         "type": "github"
       }
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760392170,
-        "narHash": "sha256-WftxJgr2MeDDFK47fQKywzC72L2jRc/PWcyGdjaDzkw=",
+        "lastModified": 1770726378,
+        "narHash": "sha256-kck+vIbGOaM/dHea7aTBxdFYpeUl/jHOy5W3eyRvVx8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "46d55f0aeb1d567a78223e69729734f3dca25a85",
+        "rev": "5eaaedde414f6eb1aea8b8525c466dc37bba95ae",
         "type": "github"
       },
       "original": {
@@ -101,16 +101,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1760349414,
-        "narHash": "sha256-W4Ri1ZwYuNcBzqQQa7NnWfrv0wHMo7rduTWjIeU9dZk=",
+        "lastModified": 1771216249,
+        "narHash": "sha256-FNEmjUiwVcbaMx+DLNAPyEZMdw4ASGvEqJaswcJVRDc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c12c63cd6c5eb34c7b4c3076c6a99e00fcab86ec",
+        "rev": "7cdb2c9a4f4ec945cdd8348800b9205e5069b48f",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixpkgs-25.11-darwin",
         "type": "indirect"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -3,10 +3,14 @@
     bellroy-nix-foss.url = "github:bellroy/bellroy-nix-foss";
   };
 
-  outputs = inputs:
+  outputs =
+    inputs:
     inputs.bellroy-nix-foss.lib.haskellProject {
       src = ./.;
-      supportedCompilers = [ "ghc92" "ghc94" "ghc96" ];
-      defaultCompiler = "ghc94";
+      supportedCompilers = [
+        "ghc94"
+        "ghc96"
+      ];
+      defaultCompiler = "ghc96";
     };
 }


### PR DESCRIPTION
## Summary
- Updated bellroy-nix-foss flake input (2025-10-14 -> 2026-02-17)
- bumped default to GHC 9.6
- Widened base upper bound from <4.22 to <4.23
- Updated tested-with to GHC 9.6.7

Note: GHC 9.8 support is blocked by `barbies-th` 0.1.11 which doesn't support the Template Haskell API changes in GHC 9.8+.

## Test plan
- [x] `cabal build all` succeeds on GHC 9.4.8
- [x] `cabal build all` succeeds on GHC 9.6.7
- [x] Project has no test suite

Post-merge: revise cabal metadata on Hackage for updated tested-with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)